### PR TITLE
Merge pull request #50 from downingmoon/feature/issue#35

### DIFF
--- a/src/test/kotlin/com/dugaza/letsdrive/service/FileServiceTest.kt
+++ b/src/test/kotlin/com/dugaza/letsdrive/service/FileServiceTest.kt
@@ -108,7 +108,7 @@ class FileServiceTest {
 
     // --- 테스트: uploadFile ---
     @Test
-    fun `uploadFile은 유효한 jpg 파일 업로드 시 FileMaster와 FileDetail을 생성한다`() {
+    fun `uploadFile should create FileMaster and FileDetail when a valid jpg file is uploaded`() {
         val userId = UUID.randomUUID()
         val dummyUser = dummyUser()
         every { userService.getUserById(userId) } returns dummyUser
@@ -148,7 +148,7 @@ class FileServiceTest {
     }
 
     @Test
-    fun `uploadFile은 사이즈 초과하는 bmp 파일은 압축하여 저장해야한다`() {
+    fun `uploadFile should compress bmp file if size exceeds maxSize`() {
         val userId = UUID.randomUUID()
         val dummyUser = dummyUser()
         every { userService.getUserById(userId) } returns dummyUser
@@ -190,7 +190,7 @@ class FileServiceTest {
     }
 
     @Test
-    fun `uploadFile은 지원하지 않는 확장자 업로드 시 예외를 던져야한다`() {
+    fun `uploadFile should throw an exception when uploading an unsupported extension`() {
         val userId = UUID.randomUUID()
         val dummyUser = dummyUser()
         every { userService.getUserById(userId) } returns dummyUser
@@ -213,7 +213,7 @@ class FileServiceTest {
     }
 
     @Test
-    fun `uploadFile은 유효하지 않은 이미지 데이터 업로드 시 예외를 던져야한다`() {
+    fun `uploadFile should throw an exception when uploading invalid image data`() {
         val userId = UUID.randomUUID()
         val dummyUser = dummyUser()
         every { userService.getUserById(userId) } returns dummyUser
@@ -239,7 +239,7 @@ class FileServiceTest {
 
     // --- 테스트: downloadFile ---
     @Test
-    fun `downloadFile은 압축해제 실패 시 예외를 던져야한다`() {
+    fun `downloadFile should throw an exception when decompression fails`() {
         val dummyDetail =
             FileDetail(
                 fileMaster = FileMaster(dummyUser()),
@@ -267,7 +267,7 @@ class FileServiceTest {
     }
 
     @Test
-    fun `getFileDetail은 존재하지 않는 파일 id 시 예외를 던져야한다`() {
+    fun `getFileDetail should thorw an exception when the file detail does not exist`() {
         val nonExistentId = UUID.randomUUID()
         every { fileDetailRepository.findById(nonExistentId) } returns Optional.empty()
 
@@ -280,7 +280,7 @@ class FileServiceTest {
 
     // --- 테스트: getDefaultImage ---
     @Test
-    fun `getDefaultImage은 기본 이미지가 없으면 예외를 던져야한다`() {
+    fun `getDefaultImage should throw an exception when default image detail does not exist`() {
         val defaultImageDetailIdField = FileService::class.java.getDeclaredField("defaultImageDetailId")
         defaultImageDetailIdField.isAccessible = true
         val defaultImageDetailId = defaultImageDetailIdField.get(fileService) as UUID
@@ -296,7 +296,7 @@ class FileServiceTest {
     }
 
     @Test
-    fun `getDefaultImage은 기본 이미지를 복제하여 FileDetail을 반환해야한다`() {
+    fun `getDefaultImage should create a copy of the default image and return a FileDetail`() {
         val defaultImageDetailIdField = FileService::class.java.getDeclaredField("defaultImageDetailId")
         defaultImageDetailIdField.isAccessible = true
         val defaultImageDetailId = defaultImageDetailIdField.get(fileService) as UUID
@@ -335,7 +335,7 @@ class FileServiceTest {
 
     // --- 테스트: 중복 파일 처리 ---
     @Test
-    fun `uploadFile은 같은 해시값의 파일에 대해 파일 저장 없이 detail만 생성해야한다`() {
+    fun `uploadFile should return new FileDetail and not store a file when a file with the same hash`() {
         val userId = UUID.randomUUID()
         val dummyUser = dummyUser()
         every { userService.getUserById(userId) } returns dummyUser

--- a/src/test/kotlin/com/dugaza/letsdrive/validator/CustomValidatorTest.kt
+++ b/src/test/kotlin/com/dugaza/letsdrive/validator/CustomValidatorTest.kt
@@ -6,14 +6,13 @@ import jakarta.validation.ConstraintViolation
 import jakarta.validation.ValidationException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CustomValidatorTest : ValidatorTestBase() {
     @Test
     fun `Custom NotNull Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 10)
         val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
         assertEquals(0, violations.size)
     }
@@ -30,14 +29,14 @@ class CustomValidatorTest : ValidatorTestBase() {
 
     @Test
     fun `Custom NotBlank Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 10)
         val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
         assertEquals(0, violations.size)
     }
 
     @Test
     fun `Custom NotBlank Fail`() {
-        val vo = ValidationTestVo("", "", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "", "abc", 10, 255, 10)
         val ex = assertThrows<ValidationException> { validator.validate(vo) }
         val t = ex.cause
         assertTrue(t is BusinessException)
@@ -47,14 +46,14 @@ class CustomValidatorTest : ValidatorTestBase() {
 
     @Test
     fun `Custom Size Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 10)
         val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
         assertEquals(0, violations.size)
     }
 
     @Test
     fun `Custom Size Fail`() {
-        val vo = ValidationTestVo("", "this is a test", "abcdefghijklmnop", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abcdefghijklmnop", 10, 255, 10)
         val ex = assertThrows<ValidationException> { validator.validate(vo) }
         val t = ex.cause
         assertTrue(t is BusinessException)
@@ -64,14 +63,14 @@ class CustomValidatorTest : ValidatorTestBase() {
 
     @Test
     fun `Custom Min Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 10)
         val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
         assertEquals(0, violations.size)
     }
 
     @Test
     fun `Custom Min Fail`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 9, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 9, 255, 10)
         val ex = assertThrows<ValidationException> { validator.validate(vo) }
         val t = ex.cause
         assertTrue(t is BusinessException)
@@ -81,14 +80,14 @@ class CustomValidatorTest : ValidatorTestBase() {
 
     @Test
     fun `Custom Max Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 10)
         val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
         assertEquals(0, violations.size)
     }
 
     @Test
     fun `Custom Max Fail`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 2555, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 2555, 10)
         val ex = assertThrows<ValidationException> { validator.validate(vo) }
         val t = ex.cause
         assertTrue(t is BusinessException)
@@ -98,35 +97,18 @@ class CustomValidatorTest : ValidatorTestBase() {
 
     @Test
     fun `Custom Range Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 10)
         val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
         assertEquals(0, violations.size)
     }
 
     @Test
     fun `Custom Range Fail`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 15)
+        val vo = ValidationTestVo(Any(), "this is a test", "abc", 10, 255, 15)
         val ex = assertThrows<ValidationException> { validator.validate(vo) }
         val t = ex.cause
         assertTrue(t is BusinessException)
         assertEquals("range 파라미터의 범위는 1 ~ 10 사이로 지정 가능합니다.", ex.cause!!.message)
         assertEquals(ErrorCode.DEFAULT_RANGE_MESSAGE, t.errorCode)
-    }
-
-    @Test
-    fun `Custom UUID NotNull Success`() {
-        val vo = ValidationTestVo("", "this is a test", "abc", 10, 255, 10, UUID.randomUUID())
-        val violations: Set<ConstraintViolation<ValidationTestVo>> = validator.validate(vo)
-        assertEquals(0, violations.size)
-    }
-
-    @Test
-    fun `Custom UUID NotNull Fail`() {
-        val vo = ValidationTestVo(null, "this is a test", "abc", 10, 255, 10, null)
-        val ex = assertThrows<ValidationException> { validator.validate(vo) }
-        val t = ex.cause
-        assertTrue(t is BusinessException)
-        assertEquals("필수 파라미터가 없습니다.", ex.cause!!.message)
-        assertEquals(ErrorCode.DEFAULT_NOT_NULL_MESSAGE, t.errorCode)
     }
 }

--- a/src/test/kotlin/com/dugaza/letsdrive/validator/ValidationTestVo.kt
+++ b/src/test/kotlin/com/dugaza/letsdrive/validator/ValidationTestVo.kt
@@ -1,11 +1,10 @@
 package com.dugaza.letsdrive.validator
 
 import com.dugaza.letsdrive.exception.ErrorCode
-import java.util.UUID
 
 class ValidationTestVo(
     @field:CustomValidator.NotNull(ErrorCode.DEFAULT_NOT_NULL_MESSAGE)
-    private val notNull: String?,
+    private val notNull: Any?,
     @field:CustomValidator.NotBlank(ErrorCode.DEFAULT_NOT_BLANK_MESSAGE)
     private val notBlank: String,
     @field:CustomValidator.Size(1, 10, ErrorCode.DEFAULT_SIZE_MESSAGE)
@@ -16,6 +15,4 @@ class ValidationTestVo(
     private val max: Int,
     @field:CustomValidator.Range(1, 10, ErrorCode.DEFAULT_RANGE_MESSAGE)
     private val range: Int,
-    @field:CustomValidator.NotNull(ErrorCode.DEFAULT_NOT_NULL_MESSAGE)
-    private val uuidNotNull: UUID? = null,
 )


### PR DESCRIPTION
### 메세지 컨버터 데이터 타입 추가
- 기존 `Int`, `Long` 등 숫자 타입 하나만 사용하던 부분을 Number 로 유연하게 받도록 함.

### Default YML Resource 이름 관련 수정
- Locale 설정이 안돼있을 경우 message_.yml 로 로드함.
- 해당 오류 수정 및 Locale white list 로 관리하여 오류 날 확률을 줄임.