### PR TITLE
OAtuth2.0 Service Refactoring

### DIFF
--- a/src/main/kotlin/com/dugaza/letsdrive/config/CorsConfig.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/config/CorsConfig.kt
@@ -11,8 +11,8 @@ class CorsConfig {
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
-        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        configuration.allowedOrigins = listOf("http://localhost:3000")
+        configuration.allowedMethods = listOf("GET", "POST")
+        configuration.allowedOrigins = listOf("http://localhost:8080")
         configuration.allowedHeaders = listOf("*")
         configuration.allowCredentials = true
 

--- a/src/main/kotlin/com/dugaza/letsdrive/config/SecurityProperties.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/config/SecurityProperties.kt
@@ -1,0 +1,18 @@
+package com.dugaza.letsdrive.config
+
+import com.dugaza.letsdrive.entity.user.Role
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "security")
+class SecurityProperties {
+    var permitAll: List<String> = mutableListOf()
+    var roleMappings: List<RoleMapping> = mutableListOf()
+    var defaultRole: String = Role.USER.name
+}
+
+data class RoleMapping(
+    val roles: List<String> = emptyList(),
+    val urls: List<String> = emptyList(),
+)

--- a/src/main/kotlin/com/dugaza/letsdrive/controller/AuthController.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/controller/AuthController.kt
@@ -1,14 +1,28 @@
 package com.dugaza.letsdrive.controller
 
+import com.dugaza.letsdrive.service.auth.TokenService
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 
 @Controller
 @RequestMapping("/api/auth")
-class AuthController {
+class AuthController(
+    private val tokenService: TokenService,
+) {
     @GetMapping("/users/login")
     fun login(): String {
         return "login-page"
+    }
+
+    @GetMapping("/users/logout")
+    fun logout(request: HttpServletRequest): ResponseEntity<Void> {
+        request.cookies.find { it.name == "ACCESS_TOKEN" }
+            ?. apply { tokenService.revokeAccessToken(value) }
+        request.cookies.find { it.name == "REFRESH_TOKEN" }
+            ?. apply { tokenService.revokeRefreshToken(value) }
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/dugaza/letsdrive/controller/MailController.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/controller/MailController.kt
@@ -13,11 +13,11 @@ class MailController(
     private val userService: UserService,
 ) {
     @GetMapping("/verify-email")
-    fun verifyEmail(
+    fun verifyMail(
         @RequestParam("token") token: String,
         model: Model,
     ): String {
-        val success = userService.verifyEmail(token)
+        val success = userService.verifyMail(token)
 
         return if (success != null) {
             model.addAttribute("nickname", success)

--- a/src/main/kotlin/com/dugaza/letsdrive/entity/user/Role.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/entity/user/Role.kt
@@ -1,7 +1,7 @@
 package com.dugaza.letsdrive.entity.user
 
-enum class Role {
-    USER,
-    UNVERIFIED_USER,
-    ADMIN,
+enum class Role(val roleName: String) {
+    USER("유저"),
+    UNVERIFIED_USER("이메일 미인증 유저"),
+    ADMIN("관리자"),
 }

--- a/src/main/kotlin/com/dugaza/letsdrive/handler/auth/CustomAuthenticationHandler.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/handler/auth/CustomAuthenticationHandler.kt
@@ -35,7 +35,7 @@ class CustomAuthenticationHandler(
             Cookie("ACCESS_TOKEN", accessToken).apply {
                 isHttpOnly = true
                 secure = request.isSecure
-                path = "/"
+                path = "/" // todo: 배포시 도메인으로 바꾸기
                 maxAge = tokenService.accessTokenDuration.toInt()
             }
         val refreshCookie =

--- a/src/main/kotlin/com/dugaza/letsdrive/service/auth/TokenService.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/service/auth/TokenService.kt
@@ -66,7 +66,7 @@ class TokenService(
     }
 
     /**
-     * Access token 검증: 유효하면 해당 userId 반환, 아니면 null
+     * Refresh token 검증: 유효하면 해당 userId 반환, 아니면 null
      */
     fun validateRefreshToken(token: String): UUID? {
         return redisUtil.getValue("refresh:$token")?.let { UUID.fromString(it) }

--- a/src/main/kotlin/com/dugaza/letsdrive/service/user/UserService.kt
+++ b/src/main/kotlin/com/dugaza/letsdrive/service/user/UserService.kt
@@ -62,12 +62,12 @@ class UserService(
                         }
                     }
                 }
-        mailService.sendMail(userId.toString(), user.nickname, email)
+        mailService.sendVerificationMail(userId, user.nickname, email)
     }
 
     @Transactional
-    fun verifyEmail(token: String): String? {
-        val (userId, email) = mailService.verifyEmail(token) ?: return null
+    fun verifyMail(token: String): String? {
+        val (userId, email) = mailService.verifyMail(token) ?: return null
         val user = getUserById(UUID.fromString(userId))
 
         user.changeEmail(email)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,6 +61,24 @@ spring:
         email: ${SENDER_EMAIL}
     auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
 
+security:
+  permit-all:
+    - /
+    - /api/auth/users/login
+    - /error
+    - /api/mail/verify-email
+    - /api/token/refresh
+  role-mappings:
+    - roles: [USER, UNVERIFIED_USER]
+      urls:
+        - /api/users/random-nickname
+        - /api/files/default-profile-image
+        - /api/users/change-email
+    - roles: [ADMIN]
+      urls:
+        - /api/admin/**
+  default-role: USER
+
 file:
   max-size: ${FILE_MAX_SIZE}
   image-extensions: ${FILE_IMAGE_EXT}


### PR DESCRIPTION
### 업데이트 내용
1. security config에서 url authorize부분 application.yml로 동적관리 할 수 있게 분리
2. mail service에서 기존에는 인증메일을 위한 내용이었는데 다른 내용의 메일도 보낼 수 있게 확장
3. role에 roleName이 추가

### SecurityConfig Authorize Url 추가 방법
- application.yml에 role mapping하기
```yml
security:
  permit-all:
    - /api/test
    - /
  role-mappings:
    - roles: [USER, UNVERIFIED_USER]
      urls:
        - /api/users/test
        - /test
    - roles: [ADMIN]
      urls:
        - /api/admin/**
  default-role: USER
```
- permit-all url들은 url만 추가하기
- url별 role지정 필요시 role-mappings에 적용하고자 하는 roles와 urls에 url 추가
---
- close #44 